### PR TITLE
subtest supported additional_args after 1.001004_001

### DIFF
--- a/lib/Test/Flatten.pm
+++ b/lib/Test/Flatten.pm
@@ -37,7 +37,7 @@ END {
 }
 
 sub subtest {
-    my ($caption, $test) = @_;
+    my ($caption, $test, @args) = @_;
 
     my $builder = Test::More->builder;
     unless (ref $test eq 'CODE') {
@@ -78,7 +78,7 @@ sub subtest {
     use strict;
 
     local $Test::Builder::Level = $Test::Builder::Level = 1;
-    my $is_passing = eval { $test->(); 1 };
+    my $is_passing = eval { $test->(@args); 1 };
     my $e = $@;
 
     die $e if $e && !eval { $e->isa('Test::Builder::Exception') };

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -16,6 +16,10 @@ subtest 'bar' => sub {
     };
 };
 
+subtest 'argument (Test::More supported after 1.001004_001)' => sub {
+    is $_[0], 'str';
+}, 'str';
+
 pass 'ok';
 
 done_testing;


### PR DESCRIPTION
https://metacpan.org/changes/distribution/Test-Simple#L13 (1.001004_001)
以降からsubtestにargsが許可されました。

Test::Flattenはuseするだけでsubtestの出力を綺麗にしてくれるということで、
その変更に追従するPRになります。

よろしくお願い致します。
