### PR TITLE
change override method, Test::More to Test::Builder

### DIFF
--- a/lib/Test/Flatten.pm
+++ b/lib/Test/Flatten.pm
@@ -14,7 +14,8 @@ our $BORDER_LENGTH = 78;
 our $CAPTION_COLOR = ['clear'];
 our $NOTE_COLOR    = ['yellow'];
 
-our $ORG_SUBTEST = Test::More->can('subtest');
+our $ORG_SUBTEST = Test::Builder->can('subtest');
+our $ORG_TEST_MORE_SUBTEST = Test::More->can('subtest');
 
 $ENV{ANSI_COLORS_DISABLED} = 1 if $^O eq 'MSWin32';
 
@@ -22,8 +23,10 @@ sub import {
     my $class = caller(0);
     no warnings qw(redefine prototype);
     no strict 'refs';
-    *{"$class\::subtest"} = \&subtest;
-    *Test::More::subtest = \&subtest;
+    *Test::Builder::subtest = \&subtest;
+
+    # backward campatibility
+    *{"$class\::subtest"} = Test::More->can('subtest');
 }
 
 my $TEST_DIFF = 0;
@@ -37,7 +40,7 @@ END {
 }
 
 sub subtest {
-    my ($caption, $test, @args) = @_;
+    my ($self, $caption, $test, @args) = @_;
 
     my $builder = Test::More->builder;
     unless (ref $test eq 'CODE') {


### PR DESCRIPTION
@xaicron さん

ぶっちゃけどっちでもいい！と言われそうですが、
Test系のモジュールを作るときはTest::Builderをオーバーライドした方がいいかな。
と思っております。

Test系のモジュールを作るときは、Test::Builderをオーバライドしているケースが多いのでは？っていう理由だけです。
- https://metacpan.org/source/TOKUHIROM/Test-Pretty-0.30/lib/Test/Pretty.pm#L52
- https://metacpan.org/source/SATOH/Test-Name-FromLine-0.13/lib/Test/Name/FromLine.pm#L18

で、僕もテスト用のモジュールを作った時に、Test::Moreではなく、Test::Builderの方のsubtestを使うように書いちゃったので、
https://metacpan.org/source/HIXI/Test-Clear-0.02/lib/Test/Clear.pm#L32
あー、Test::Flattenのsubtest使えないなーと思って、PR送ってしまいました。

利点は、上のようなテスト用モジュールと共有できるようになる。
欠点は、Test::Moreのsubtestをオーバライドするようなモジュールを作られた時に撃ち負ける。

です。お考えを聞かせていただくm m
